### PR TITLE
fix: remove non-existent columns from Problem_set insert

### DIFF
--- a/src/lib/components/CreateNewSet.svelte
+++ b/src/lib/components/CreateNewSet.svelte
@@ -11,8 +11,6 @@
 <Modal {show} {closeModal}>
 	<form method="POST" action="?/createPset">
 		<input type="hidden" name="owner_email" value={email} />
-		<input type="hidden" name="owner_name" value={name} />
-		<input type="hidden" name="owner_picture" value={pictureURL} />
 		<input
 			type="text"
 			placeholder="Problem Set Name"

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -67,8 +67,6 @@ export const actions = {
                     title: formData.get('title'),
                     description: formData.get('description'),
                     owner_email: formData.get('owner_email'),
-                    author_name: formData.get('author_name'),
-                    author_profile_url: formData.get('author_picture'),
                     auto_accept: formData.get('auto_accept') === 'on' ? true : false,
                     is_global: formData.get('is_private') === 'on' ? false : true,
                 };  


### PR DESCRIPTION
Remove author_name and author_profile_url from the createPset action insert object - these columns don't exist in the Problem_set table, causing Supabase to reject the insert with PGRST204.

Also remove the corresponding unused hidden form fields (owner_name, owner_picture) from CreateNewSet.svelte.